### PR TITLE
Use ID for notification object if passed to addNotification method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-notifications-component",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "homepage": "http://teodosii.github.io/react-notifications-component",
   "description": "React component for creating notifications on the fly",
   "main": "dist/react-notifications-component.js",

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -382,11 +382,12 @@ export function getNotificationOptions(options, userDefinedTypes) {
     touchSlidingExit,
     dismissable,
     dismiss,
-    width
+    width,
+    id
   } = notification;
 
-  // for now we'll use Math.random for id
-  notification.id = getRandomId();
+  // Use notification id if passed or generate random ID
+  notification.id = id || getRandomId();
 
   // validate notification's title
   validateTitle(notification);


### PR DESCRIPTION
Currently random ID is generated for notification and is passed on onNotificationRemoval. Using this random ID we cannot identify the notification object in redux state for cleaning. So I have passed the ID generated by app and used for creating notification object.