### PR TITLE
Added className to iContainerProps

### DIFF
--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -19,6 +19,7 @@ interface iContainerProps {
   breakpoint?: number
   types?: iNotificationCustomType[]
   defaultNotificationWidth?: number
+  className?: string
 }
 
 interface iContainerState {


### PR DESCRIPTION
I got this error when passing the `className` prop to `ReactNotifications`:
` Property 'className' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Container> & Readonly<iContainerProps> & Readonly<...>`