### PR TITLE
Prevent onTransitionEnd to be called multiple times

### DIFF
--- a/src/components/Notification.tsx
+++ b/src/components/Notification.tsx
@@ -53,7 +53,7 @@ class Notification extends React.Component<iNotificationProps, iNotificationStat
     const { scrollHeight } = this.rootElementRef.current
 
     const onTransitionEnd = () => {
-      if (!duration || onScreen) return
+      if (!duration || onScreen || this.timer) return
       const callback = () => this.removeNotification(NOTIFICATION_REMOVAL_SOURCE.TIMEOUT)
       this.timer = new Timer(callback, duration)
     }


### PR DESCRIPTION
I have and issue where setting pauseOnHover has no effect. After spending some time to determine where the issues is, i identified, that this is due to onTransitionEnd called twice. This creates new timer and even if you try to pause time during mouse over, old timer keeps running and closes the notification.

This PR prevent onTransitionEnd  to be called twice. Otherwise it has no other side effects. I would appreciate if this could be merged and patch version released.

Thanks!